### PR TITLE
added node-version 20, 21, 22 for windows/macos/linux binaries

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: [8, 10, 12, 14, 15, 16, 17, 18, 19]
+        node-version: [8, 10, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: [8, 10, 12, 14, 15, 16, 17, 18, 19]
+        node-version: [8, 10, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: [8, 10, 12, 14, 15, 16, 17, 18, 19]
+        node-version: [8, 10, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
I need this package to be available for Node 20 on the project I'm currently working on.
I raised this issue https://github.com/microsoft/ApplicationInsights-node.js-native-metrics/issues/60, so I thought I could update the workflows to help everyone.

@microsoft-github-policy-service agree