### PR TITLE
Update CodeQL to Ignore .gyp Files and Compile C++

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -6,3 +6,4 @@ queries:
 paths-ignore:
   - '**/tests/'
   - '**/out/'
+  - '**/*.gyp'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,6 +4,6 @@ queries:
   - uses: security-and-quality
 
 paths-ignore:
-  - '**/tests/'
+  - '**/test/'
   - '**/out/'
   - '**/*.gyp'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,7 +55,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -69,4 +69,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: [ 'cpp' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -71,4 +71,4 @@ jobs:
     #     done
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,6 +64,14 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
+    - name: Install Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '20'
+        
+    - name: Install NAN
+      run: npm install nan
+
     - name: Install dependencies
       run: sudo apt-get install -y g++
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -95,6 +95,7 @@ jobs:
     - name: Build
       run: |
         node-gyp configure
+        npm install -g nan
         node-gyp rebuild
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -76,7 +76,7 @@ jobs:
       run: npm install -g node-gyp
 
     - name: Install node-pre-gyp globally
-      run: npm install -g node-pre-gyp install --fallback-to-build
+      run: node-pre-gyp install --fallback-to-build
 
     - name: Install nan globally
       run: npm install -g nan

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -85,7 +85,6 @@ jobs:
 
     - name: Build
       run: |
-        cd src
         node-gyp configure
         node-gyp build
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -72,6 +72,9 @@ jobs:
     - name: Install node-pre-gyp globally
       run: npm install -g @mapbox/node-pre-gyp
 
+    - name: Install node-pre-gyp globally
+      run: npm install -g node-gyp
+
     - name: Install nan globally
       run: npm install -g nan
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -72,9 +72,6 @@ jobs:
     - name: Install node-pre-gyp globally
       run: npm install -g @mapbox/node-pre-gyp
 
-    - name: Install node-pre-gyp globally
-      run: npm install -g node-gyp
-
     - name: Install nan globally
       run: npm install -g nan
 
@@ -91,7 +88,8 @@ jobs:
 
     - name: Build
       run: |
-        node-pre-gyp rebuild
+        node-gyp configure
+        node-gyp rebuild
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -73,7 +73,9 @@ jobs:
       run: npm install -g node-gyp
 
     - name: Install nan globally
-      run: npm install -g nan
+      run: |
+        npm install -g nan
+        export NODE_PATH=$(npm root -g)
 
     - name: Install Python
       uses: actions/setup-python@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -70,7 +70,7 @@ jobs:
         node-version: '20'
 
     - name: Install node-gyp
-      run: npm install -g node-gyp
+      run: npm install node-gyp
         
     - name: Install NAN
       run: npm install nan
@@ -82,7 +82,7 @@ jobs:
       run: node-gyp configure
 
     - name: Compile GcProfiler
-      run: g++ -c GcProfiler.cc -o GcProfiler.o -I./node_modules/nan -I$(node -p "require('node-gyp').findNodeDirectory()")/include/node
+      run: g++ -c src/GcProfiler.cc -o src/GcProfiler.o -I./node_modules/nan -I$(node -p "require('node-gyp').findNodeDirectory()")/include/node
 
     - name: Compile LoopProfiler
       run: g++ -c src/LoopProfiler.cc -o LoopProfiler.o

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -72,6 +72,9 @@ jobs:
     - name: Install node-gyp globally
       run: npm install -g node-gyp
 
+    - name: Install nan globally
+      run: npm install -g nan
+
     - name: Install Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -69,8 +69,11 @@ jobs:
       with:
         node-version: '16'
 
-    - name: Install NPM Dependencies
-      run: npm install
+    - name: Install node-pre-gyp globally
+      run: npm install -g @mapbox/node-pre-gyp
+
+    - name: Install nan globally
+      run: npm install -g nan
 
     - name: Install Python
       uses: actions/setup-python@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -67,10 +67,10 @@ jobs:
     - name: Install Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '20'
+        node-version: '16'
 
     - name: Install node-gyp
-      run: npm install node-gyp
+      run: npm install -g node-gyp
         
     - name: Install NAN
       run: npm install nan

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,8 +54,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    # - name: Autobuild
+    #   uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,9 +64,9 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - run: |
+        make bootstrap
+        make release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -94,8 +94,8 @@ jobs:
 
     - name: Build
       run: |
-        node-gyp configure
         npm install -g nan
+        node-gyp configure
         node-gyp rebuild
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -68,6 +68,9 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: '20'
+
+    - name: Install node-gyp
+      run: npm install -g node-gyp
         
     - name: Install NAN
       run: npm install nan
@@ -75,8 +78,11 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get install -y g++
 
-    - name: Compile GCProfiler
-      run: g++ -c src/GcProfiler.cc -o GcProfiler.o -I./node_modules/nan
+    - name: Configure node-gyp
+      run: node-gyp configure
+
+    - name: Compile GcProfiler
+      run: g++ -c GcProfiler.cc -o GcProfiler.o -I./node_modules/nan -I$(node -p "require('node-gyp').findNodeDirectory()")/include/node
 
     - name: Compile LoopProfiler
       run: g++ -c src/LoopProfiler.cc -o LoopProfiler.o

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -69,13 +69,8 @@ jobs:
       with:
         node-version: '16'
 
-    - name: Install node-gyp globally
-      run: npm install -g node-gyp
-
-    - name: Install nan globally
-      run: |
-        npm install -g nan
-        export NODE_PATH=$(npm root -g)
+    - name: Install NPM Dependencies
+      run: npm install
 
     - name: Install Python
       uses: actions/setup-python@v2
@@ -90,8 +85,7 @@ jobs:
 
     - name: Build
       run: |
-        node-gyp configure
-        node-gyp build
+        node-pre-gyp rebuild
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -94,7 +94,7 @@ jobs:
 
     - name: Build
       run: |
-        npm install -g nan
+        npm install --save nan
         node-gyp configure
         node-gyp rebuild
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,10 +54,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      env:
-        CODEQL_EXTRACTOR_CPP_TRACING_DIRECTORY: src
-      uses: github/codeql-action/autobuild@v3
+    # - name: Autobuild
+    #   uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -66,11 +64,23 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    # - run: |
-    #     mkdir -p build
-    #     for file in src/*.cpp; do
-    #       g++ -o build/${file%.cpp} $file
-    #     done
+    - name: Install dependencies
+      run: sudo apt-get install -y g++
+
+    - name: Compile GCProfiler
+      run: g++ -c GCProfiler.cc -o GCProfiler.o
+
+    - name: Compile LoopProfiler
+      run: g++ -c LoopProfiler.cc -o LoopProfiler.o
+
+    - name: Compile ResourceProfiler
+      run: g++ -c ResourceProfiler.cc -o ResourceProfiler.o
+
+    - name: Compile native_metric
+      run: g++ -c native_metric.cc -o native_metric.o
+
+    - name: Link objects
+      run: g++ GCProfiler.o LoopProfiler.o ResourceProfiler.o native_metric.o -o profiler_executable
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -69,32 +69,25 @@ jobs:
       with:
         node-version: '16'
 
-    - name: Install node-gyp
+    - name: Install node-gyp globally
       run: npm install -g node-gyp
-        
-    - name: Install NAN
-      run: npm install nan
 
-    - name: Install dependencies
-      run: sudo apt-get install -y g++
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    
+    - name: Install Make
+      run: sudo apt-get update && sudo apt-get install -y make
 
-    - name: Configure node-gyp
-      run: node-gyp configure
+    - name: Install GCC
+      run: sudo apt-get update && sudo apt-get install -y gcc
 
-    - name: Compile GcProfiler
-      run: g++ -c src/GcProfiler.cc -o src/GcProfiler.o -I./node_modules/nan -I$(node -p "require('node-gyp').findNodeDirectory()")/include/node
-
-    - name: Compile LoopProfiler
-      run: g++ -c src/LoopProfiler.cc -o LoopProfiler.o
-
-    - name: Compile ResourceProfiler
-      run: g++ -c src/ResourceProfiler.cc -o ResourceProfiler.o
-
-    - name: Compile native_metric
-      run: g++ -c src/native_metrics.cc -o native_metrics.o
-
-    - name: Link objects
-      run: g++ GcProfiler.o LoopProfiler.o ResourceProfiler.o native_metrics.o -o profiler_executable
+    - name: Build
+      run: |
+        cd src
+        node-gyp configure
+        node-gyp build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -54,8 +54,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    # - name: Autobuild
-    #   uses: github/codeql-action/autobuild@v2
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,11 +64,11 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    - run: |
-        mkdir -p build
-        for file in src/*.cpp; do
-          g++ -o build/${file%.cpp} $file
-        done
+    # - run: |
+    #     mkdir -p build
+    #     for file in src/*.cpp; do
+    #       g++ -o build/${file%.cpp} $file
+    #     done
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -76,7 +76,7 @@ jobs:
       run: sudo apt-get install -y g++
 
     - name: Compile GCProfiler
-      run: g++ -c src/GcProfiler.cc -o GcProfiler.o
+      run: g++ -c src/GcProfiler.cc -o GcProfiler.o -I./node_modules/nan
 
     - name: Compile LoopProfiler
       run: g++ -c src/LoopProfiler.cc -o LoopProfiler.o

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,6 +55,8 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
+      env:
+        CODEQL_EXTRACTOR_CPP_TRACING_DIRECTORY: src
       uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -68,16 +68,16 @@ jobs:
       run: sudo apt-get install -y g++
 
     - name: Compile GCProfiler
-      run: g++ -c GcProfiler.cc -o GcProfiler.o
+      run: g++ -c src/GcProfiler.cc -o GcProfiler.o
 
     - name: Compile LoopProfiler
-      run: g++ -c LoopProfiler.cc -o LoopProfiler.o
+      run: g++ -c src/LoopProfiler.cc -o LoopProfiler.o
 
     - name: Compile ResourceProfiler
-      run: g++ -c ResourceProfiler.cc -o ResourceProfiler.o
+      run: g++ -c src/ResourceProfiler.cc -o ResourceProfiler.o
 
     - name: Compile native_metric
-      run: g++ -c native_metrics.cc -o native_metrics.o
+      run: g++ -c src/native_metrics.cc -o native_metrics.o
 
     - name: Link objects
       run: g++ GcProfiler.o LoopProfiler.o ResourceProfiler.o native_metrics.o -o profiler_executable

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -68,7 +68,7 @@ jobs:
       run: sudo apt-get install -y g++
 
     - name: Compile GCProfiler
-      run: g++ -c GCProfiler.cc -o GCProfiler.o
+      run: g++ -c GcProfiler.cc -o GcProfiler.o
 
     - name: Compile LoopProfiler
       run: g++ -c LoopProfiler.cc -o LoopProfiler.o
@@ -77,10 +77,10 @@ jobs:
       run: g++ -c ResourceProfiler.cc -o ResourceProfiler.o
 
     - name: Compile native_metric
-      run: g++ -c native_metric.cc -o native_metric.o
+      run: g++ -c native_metrics.cc -o native_metrics.o
 
     - name: Link objects
-      run: g++ GCProfiler.o LoopProfiler.o ResourceProfiler.o native_metric.o -o profiler_executable
+      run: g++ GcProfiler.o LoopProfiler.o ResourceProfiler.o native_metrics.o -o profiler_executable
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -65,8 +65,10 @@ jobs:
     #    uses a compiled language
 
     - run: |
-        make bootstrap
-        make release
+        mkdir -p build
+        for file in src/*.cpp; do
+          g++ -o build/${file%.cpp} $file
+        done
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -72,6 +72,12 @@ jobs:
     - name: Install node-pre-gyp globally
       run: npm install -g @mapbox/node-pre-gyp
 
+    - name: Install Node gyp
+      run: npm install -g node-gyp
+
+    - name: Install node-pre-gyp globally
+      run: npm install -g node-pre-gyp install --fallback-to-build
+
     - name: Install nan globally
       run: npm install -g nan
 


### PR DESCRIPTION
Code QL believes we have Python files to compile because of these .gyp config files. Updating our github workflow to ignore these.

Also update the auto codeQL builder to attempt to build the .cpp files instead of .js files.