### PR TITLE
ci: add node 24 to binary build

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: [8, 10, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22]
+        node-version: [8, 10, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22, 24]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: [8, 10, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22]
+        node-version: [8, 10, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22, 24]
     steps:
       - uses: actions/checkout@v2
       - name: Install setuptools

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: [8, 10, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22]
+        node-version: [8, 10, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22, 24]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Extend GitHub workflow build matrix for binaries with Node.js 24. This way, binaries for windows/linux/mac will be available when installing for Node.js 24.